### PR TITLE
box ci-plan: add verbose option

### DIFF
--- a/lib/Dobby/Boxmate/App.pm
+++ b/lib/Dobby/Boxmate/App.pm
@@ -67,12 +67,13 @@ sub _read_plan_file ($self, $filename) {
   return YAML::XS::Load($content);
 }
 
-sub _write_plan_file ($self, $filename, $data) {
+sub _write_plan_file ($self, $filename, $data, $verbose = undef) {
   require Path::Tiny;
   require YAML::XS;
   local $YAML::XS::Boolean = 'boolean';
   my $content = YAML::XS::Dump($data);
   Path::Tiny::path($filename)->spew($content);
+  print "Plan:\n" . $content if $verbose;
   return;
 }
 

--- a/lib/Dobby/Boxmate/App/Command/ciplan.pm
+++ b/lib/Dobby/Boxmate/App/Command/ciplan.pm
@@ -14,6 +14,7 @@ sub command_names {
 sub opt_spec {
   return (
     [ 'run-id=s', 'CI run id, defaults to $CI_JOB_ID or a guid' ],
+    [ 'verbose|v', 'Print plan to stdout'],
   );
 }
 
@@ -105,7 +106,7 @@ sub execute ($self, $opt, $args) {
   };
 
   my $plan_file = $args->[0] // $self->app->_default_plan_file;
-  $self->app->_write_plan_file($plan_file, $plan);
+  $self->app->_write_plan_file($plan_file, $plan, $opt->verbose);
   return;
 }
 


### PR DESCRIPTION
Hit an issue where CI wasn't successfully spinning up a box, problem was simple but took a while to figure out.  Would have been a LOT faster if the ci plan was printed to see in gitlab output.

I don't love that i've made a _write_plan_file() sub print to stdout, but the alternative was doing it in the ci-plan directly which would mean converting it to yaml in two places.  I'm rather ambivalent though how this is done, so if you prefer another way just let me know