### PR TITLE
ci: put reporting artifacts in /tmp/ci-run

### DIFF
--- a/lib/Dobby/Boxmate/App/Command/ciretrieve.pm
+++ b/lib/Dobby/Boxmate/App/Command/ciretrieve.pm
@@ -55,7 +55,7 @@ sub execute ($self, $opt, $args) {
         -o ControlMaster=no
         -r
     ),
-    "root\@$ip:/tmp/run-" . $plan->{run_id},
+    "root\@$ip:/tmp/ci-run",
     $opt->target . "/run-$plan->{run_id}",
   );
 

--- a/misc/test-runner-on-vm
+++ b/misc/test-runner-on-vm
@@ -479,7 +479,7 @@ package main;
 
 my $testproc = TestProcess->new({
   run_id => $run_id,
-  root   => "/tmp/run-" . $run_id,
+  root   => "/tmp/ci-run",
 });
 
 my @instructions = $plan->{program}->@*;


### PR DESCRIPTION
That gives us a fixed directory name -- nothing *really* needs to use one VM for multiple runs, and our normal planning gets in the way of doing that anyway.  Probably I was the only person who ever did it, and more people will benefit from a fixed directory name.