### PR TITLE
test-runner-on-vm: Disable apparmor for cyrus before cass run

### DIFF
--- a/misc/test-runner-on-vm
+++ b/misc/test-runner-on-vm
@@ -431,6 +431,9 @@ sub STEP_cassandane ($self, @args) {
 
   my $root = $self->root;
 
+  # Temp hack, don't let security get in the way of testing
+  $self->run_cmd("sudo aa-disable /etc/apparmor.d/cyrus");
+
   my $cmd = join q{ && },
     qq{set -o pipefail},
     qq{set -x},


### PR DESCRIPTION
Otherwise, currently, tests can't run because the profile is too strict.